### PR TITLE
tweaking template to use Authorize for delete and removing template var

### DIFF
--- a/template_content/smart_contracts/helloworld.py
+++ b/template_content/smart_contracts/helloworld.py
@@ -1,14 +1,14 @@
 from beaker.application import Application
-from beaker.decorators import delete, external
-from pyteal import Approve, Bytes, Concat, Cond, Expr, Global, Tmpl, Txn
+from beaker.decorators import Authorize, delete, external
+from pyteal import Approve, Bytes, Concat, Expr, Global
 from pyteal.ast import abi
 
 
 class HelloWorld(Application):
     @external(read_only=True)
     def hello(self, name: abi.String, *, output: abi.String) -> Expr:
-        return output.set(Concat(Tmpl.Bytes("TMPL_GREETING"), Bytes(", "), name.get()))
+        return output.set(Concat(Bytes("Hello, "), name.get()))
 
-    @delete
+    @delete(authorize=Authorize.only(Global.creator_address()))
     def delete(self) -> Expr:
-        return Cond([Txn.sender() == Global.creator_address(), Approve()])
+        return Approve()

--- a/template_content/smart_contracts/lab.py
+++ b/template_content/smart_contracts/lab.py
@@ -3,7 +3,6 @@ from shutil import rmtree
 from typing import Sequence
 
 from beaker.application import Application
-
 from smart_contracts.helloworld import HelloWorld
 
 


### PR DESCRIPTION
We can use the built-in `authorize` feature to make the `delete` method easier.

Also removing the TMPL var since its more of an advanced feature than I think the hello world should illustrate