### PR TITLE
tweak path of python cmd

### DIFF
--- a/template_content/README.md.jinja
+++ b/template_content/README.md.jinja
@@ -26,7 +26,7 @@ This project has been generated using AlgoKit. See below for default getting sta
    - Other
      1. Open the repository root in your text editor of choice
      2. In a terminal run `poetry shell`
-     3. Run `python -m ./smart_contracts` through your debugger of choice
+     3. Run `python -m smart_contracts` through your debugger of choice
 
 ### Subsequently
 


### PR DESCRIPTION
With the relative path I get:
```sh
(wiggly-py3.10) ben@Algo-Guidarelli:~/wiggly$ python -m ./smart_contracts
/home/ben/wiggly/.venv/bin/python: Relative module names not supported
```
removing the `./` provides what we want
```sh
(wiggly-py3.10) ben@Algo-Guidarelli:~/wiggly$ python -m smart_contracts
Compiling Beaker smart contracts...
Compiling helloworld.HelloWorld to /home/ben/wiggly/smart_contracts/artifacts/helloworld.HelloWorld
```