### PR TITLE
Ignore Ruff "F403" (allow star imports)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 line-length = 120
 select = ["E", "F", "ANN", "UP", "N", "C", "B", "A", "YTT", "W", "FBT", "Q", "RUF", "I"]
-ignore = ["ANN101", "C901", "F403"]
+ignore = ["ANN101", "C901", "F403", "F405"]
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 line-length = 120
 select = ["E", "F", "ANN", "UP", "N", "C", "B", "A", "YTT", "W", "FBT", "Q", "RUF", "I"]
-ignore = ["ANN101", "C901"]
+ignore = ["ANN101", "C901", "F403"]
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",


### PR DESCRIPTION
Strict linting for imports can be really annoying especially when first getting started with a new library. I think it would be beneficial to ignore this rule in the default template.