### PR TITLE
fix: remove readonly flag from external decorator

### DIFF
--- a/template_content/smart_contracts/helloworld.py
+++ b/template_content/smart_contracts/helloworld.py
@@ -13,6 +13,6 @@ app = (
 )
 
 
-@app.external(read_only=True)
+@app.external
 def hello(name: pt.abi.String, *, output: pt.abi.String) -> pt.Expr:
     return output.set(pt.Concat(pt.Bytes("Hello, "), name.get()))


### PR DESCRIPTION
readonly calls will not submit real transactions to the network, only dryrun them. 

This would still return the value we expect ("Hello, name") but the dev wont be able to see the transaction in the algod or indexer
