### PR TITLE
Update Python default formatter

### DIFF
--- a/template_content/{% if ide_vscode %}.vscode{% endif %}/settings.json.jinja
+++ b/template_content/{% if ide_vscode %}.vscode{% endif %}/settings.json.jinja
@@ -24,7 +24,7 @@
       // Prevent default import sorting from running; Ruff will sort imports for us anyway
       "source.organizeImports": false
     },
-    "editor.defaultFormatter": null
+    "editor.defaultFormatter": "ms-python.black-formatter"
   },
   {% if use_python_pytest -%}
   "python.testing.pytestEnabled": true,


### PR DESCRIPTION
When using the template with the CI/CD GitHub job "Perform Checks" (checks.yaml), the job will fail on the "Check formatting with Black" step if Black has not been run on changed files.  The step error will resemeble the following:

```
Run # stop the build if there are files that don't meet formatting requirements
would reformat /home/runner/work/algokit-cicd/algokit-cicd/smart_contracts/config.py

Oh no! 💥 💔 💥
1 file would be reformatted, 10 files would be left unchanged.
Error: Process completed with exit code 1.
```

Updating the settings.json to set `"editor.defaultFormatter": "ms-python.black-formatter"`, combined with the existing setting `"editor.formatOnSave": true`, will ensure that any file touched will format automatically on save and avoid CI/CD failures.

This change has been tested on MacOS.  Additional testing for success on other platforms is recommended.