### PR TITLE
refactor: removing templatization for deploy:ci script for typescript deployer

### DIFF
--- a/template_content/smart_contracts/{% if deployment_language == 'typescript' %}package.json{% endif %}.jinja
+++ b/template_content/smart_contracts/{% if deployment_language == 'typescript' %}package.json{% endif %}.jinja
@@ -5,9 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "deploy": "ts-node-dev --transpile-only --watch .env -r dotenv/config index.ts",
-{%- if use_github_actions %}
     "deploy:ci": "ts-node --transpile-only -r dotenv/config index.ts",
-{%- endif %}
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/tests_generated/test_use_github_actions-False_deployment_language-typescript/smart_contracts/package.json
+++ b/tests_generated/test_use_github_actions-False_deployment_language-typescript/smart_contracts/package.json
@@ -5,6 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "deploy": "ts-node-dev --transpile-only --watch .env -r dotenv/config index.ts",
+    "deploy:ci": "ts-node --transpile-only -r dotenv/config index.ts",
     "format": "prettier --write ."
   },
   "dependencies": {


### PR DESCRIPTION
# Proposed changes

Removing templatization for deploy:ci, this will significantly simplify the full stack template and as we discussed @robdmoore it makes sense to keep it as default as users may have other use cases where this command is useful 