### PR TITLE
fix: correctly nest the npm install pre-req in the generated readme

### DIFF
--- a/template_content/README.md.jinja
+++ b/template_content/README.md.jinja
@@ -16,7 +16,7 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
 {%- if deployment_language == "typescript" %}
-     - Run `npm install` to install NPM packages
+   - Run `npm install` to install NPM packages
 {% endif %}
 3. Open the project and start debugging / developing via:
    - VS Code

--- a/template_content/README.md.jinja
+++ b/template_content/README.md.jinja
@@ -17,7 +17,7 @@ This project has been generated using AlgoKit. See below for default getting sta
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
 {%- if deployment_language == "typescript" %}
    - Run `npm install` to install NPM packages
-{% endif %}
+{%- endif %}
 3. Open the project and start debugging / developing via:
    - VS Code
      1. Open the repository root in VS Code

--- a/tests_generated/test_deployment_language-typescript/README.md
+++ b/tests_generated/test_deployment_language-typescript/README.md
@@ -15,7 +15,7 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Run `poetry install` in the root directory, which will set up a `.venv` folder with a Python virtual environment and also install all Python dependencies
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
-     - Run `npm install` to install NPM packages
+   - Run `npm install` to install NPM packages
 
 3. Open the project and start debugging / developing via:
    - VS Code

--- a/tests_generated/test_deployment_language-typescript/README.md
+++ b/tests_generated/test_deployment_language-typescript/README.md
@@ -16,7 +16,6 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
    - Run `npm install` to install NPM packages
-
 3. Open the project and start debugging / developing via:
    - VS Code
      1. Open the repository root in VS Code

--- a/tests_generated/test_smart_contract_generator_default_production_preset_typescript/README.md
+++ b/tests_generated/test_smart_contract_generator_default_production_preset_typescript/README.md
@@ -15,7 +15,7 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Run `poetry install` in the root directory, which will set up a `.venv` folder with a Python virtual environment and also install all Python dependencies
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
-     - Run `npm install` to install NPM packages
+   - Run `npm install` to install NPM packages
 
 3. Open the project and start debugging / developing via:
    - VS Code

--- a/tests_generated/test_smart_contract_generator_default_production_preset_typescript/README.md
+++ b/tests_generated/test_smart_contract_generator_default_production_preset_typescript/README.md
@@ -16,7 +16,6 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
    - Run `npm install` to install NPM packages
-
 3. Open the project and start debugging / developing via:
    - VS Code
      1. Open the repository root in VS Code

--- a/tests_generated/test_smart_contract_generator_default_starter_preset_typescript/README.md
+++ b/tests_generated/test_smart_contract_generator_default_starter_preset_typescript/README.md
@@ -15,7 +15,7 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Run `poetry install` in the root directory, which will set up a `.venv` folder with a Python virtual environment and also install all Python dependencies
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
-     - Run `npm install` to install NPM packages
+   - Run `npm install` to install NPM packages
 
 3. Open the project and start debugging / developing via:
    - VS Code

--- a/tests_generated/test_smart_contract_generator_default_starter_preset_typescript/README.md
+++ b/tests_generated/test_smart_contract_generator_default_starter_preset_typescript/README.md
@@ -16,7 +16,6 @@ This project has been generated using AlgoKit. See below for default getting sta
      - Copy `.env.template` to `.env`
    - Run `algokit localnet start` to start a local Algorand network in Docker. If you are using VS Code launch configurations provided by the template, this will be done automatically for you.
    - Run `npm install` to install NPM packages
-
 3. Open the project and start debugging / developing via:
    - VS Code
      1. Open the repository root in VS Code


### PR DESCRIPTION
Tiny fix to correctly nest the npm install command within the generated README