### PR TITLE
chore: removing hardcoded env var loading for localnet

### DIFF
--- a/examples/generators/production_beaker_smart_contract_python/smart_contracts/__main__.py
+++ b/examples/generators/production_beaker_smart_contract_python/smart_contracts/__main__.py
@@ -18,8 +18,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 

--- a/examples/generators/production_beaker_smart_contract_typescript/smart_contracts/__main__.py
+++ b/examples/generators/production_beaker_smart_contract_typescript/smart_contracts/__main__.py
@@ -12,8 +12,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 

--- a/examples/generators/starter_beaker_smart_contract_python/smart_contracts/__main__.py
+++ b/examples/generators/starter_beaker_smart_contract_python/smart_contracts/__main__.py
@@ -18,8 +18,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 

--- a/examples/generators/starter_beaker_smart_contract_typescript/smart_contracts/__main__.py
+++ b/examples/generators/starter_beaker_smart_contract_typescript/smart_contracts/__main__.py
@@ -12,8 +12,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 

--- a/examples/production_beaker/smart_contracts/__main__.py
+++ b/examples/production_beaker/smart_contracts/__main__.py
@@ -18,8 +18,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 

--- a/examples/starter_beaker/smart_contracts/__main__.py
+++ b/examples/starter_beaker/smart_contracts/__main__.py
@@ -18,8 +18,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 

--- a/template_content/smart_contracts/__main__.py.jinja
+++ b/template_content/smart_contracts/__main__.py.jinja
@@ -20,8 +20,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logger.info("Loading .env")
+# For manual script execution (bypassing `algokit project deploy`) with a custom .env,
+# modify `load_dotenv()` accordingly. For example, `load_dotenv('.env.localnet')`.
 load_dotenv()
-load_dotenv(".env.localnet")
 root_path = Path(__file__).parent
 
 


### PR DESCRIPTION
## Proposed Changes

- Remove a hotfix that was addressing outdated readme instructions to allow executing smart contracts module for deploy directly without using algokit project deploy. Later PRs improved the docs and direct running deploy directly is not longer incentivized by the quick start guide hence instead of always loading the .env.localnet - its left as a comment for more advanced users. 
- Hotfix behaviour was invalid as it was clashing with other env vars. @CiottiGiorgio  reported that due to this statement, deploying to any other custom network would clash since by default we don't specify empty env vars for things like PORT, Token and etc for testnet/mainnet nodely api access (while hardcoded load of localnet would set localnet specific values that would clash). 
