### PR TITLE
chore: ensuring codetours are included by default but cutomizable on custom preset

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -62,7 +62,7 @@ code_tours:
   type: bool
   help: Do you want to add interactive VSCode CodeTour walkthrough?
   when: "{{ preset_name == 'custom' }}"
-  default: "{{ 'yes' if ide_vscode == yes else 'no' }}"
+  default: yes
 
 ide_jetbrains:
   type: bool


### PR DESCRIPTION
## Proposed Changes

- Minor one liner as a follow up to changes introduced in https://github.com/algorandfoundation/algokit-python-template/pull/24. Copier has issues with rendering code_tours answer when relying on parametrized output of ide_vscode and also being hidden by default. Simplifying that by setting the behaviour to true by default yet its still is fully customizable in Custom preset 