### PR TITLE
chore: deprecate beaker template with explicit question + warning & exit task

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -1,33 +1,74 @@
 _subdirectory: template_content
 _templates_suffix: ".jinja"
 
-_tasks:
-  - "python -c \"print('WARNING: This template has been deprecated. Beaker for Algorand Smart Contract development is no longer supported.\\nPlease use Algorand Python instead. The Algorand Python template can be found at https://github.com/algorandfoundation/algokit-python-template')\""
-  - "python -c \"exit(1)\""
+use_deprecated_template:
+  type: bool
+  help: |
+    WARNING: This template has been deprecated. Beaker for Algorand Smart Contract development is no longer supported.
+    Please use Algorand Python instead. The Algorand Python template can be found at https://github.com/algorandfoundation/algokit-python-template
+    Do you still want to proceed with using the deprecated template?
+  default: no
 
+_tasks:
+  - command: '"{{ python_path if python_path else _copier_python }}" post_init.py {{ use_deprecated_template }} {{ use_workspace }}'
+    when: "{{ _copier_conf.os in  ['linux', 'macos'] }}"
+  - command: |
+      powershell -NoProfile -ExecutionPolicy Bypass -Command "& {
+        $useDeprecated = ('{{ use_deprecated_template }}' -eq 'True');
+        $useWorkspace = ('{{ use_workspace }}' -eq 'True');
+
+        if (-not $useDeprecated) {
+          Write-Host 'WARNING: Template generation cancelled!';
+          Write-Host 'This template is deprecated. Use Algorand Python instead: https://github.com/algorandfoundation/algokit-python-template';
+
+          $projectDir = Get-Location;
+          if ($useWorkspace) {
+            $projectDir = $projectDir.Parent;
+          }
+
+          Set-Location $projectDir.Parent;
+          Remove-Item -LiteralPath $projectDir -Recurse -Force;
+
+          exit 1;
+        } else {
+          Write-Host 'Proceeding with deprecated template generation...';
+        }
+      }"
+    when: "{{ _copier_conf.os == 'windows' }}"
+    
 use_workspace:
   type: bool
-  when: false # never prompted to user explicitly, instead expect cli to auto fill (supported cli versions > v1.13.x)
+  when: false  # never prompted to user explicitly, expect CLI to auto-fill
   help: Automatically filled by AlgoKit CLI (>1.13.x) - passes the --workspace/--no-workspace flag's value, can be used to reason whether this template is currently being instantiated as part of a workspace or not.
   default: no
+
+# Auto determined by algokit-cli from v1.11.3 to allow execution of python script
+# in binary mode.
+python_path:
+  type: str
+  help: Path to the sys.executable.
+  when: false
 
 # questions
 project_name:
   type: str
   help: Name for this project.
   placeholder: "algorand-app"
+  when: "{{ use_deprecated_template }}"
 
 author_name:
   type: str
   help: Package author name
   placeholder: "Your Name"
   default: "Your Name"
+  when: "{{ use_deprecated_template }}"
 
 author_email:
   type: str
   help: Package author email
   placeholder: "your@email.tld"
   default: "your@email.tld"
+  when: "{{ use_deprecated_template }}"
 
 contract_name:
   type: str
@@ -38,6 +79,7 @@ contract_name:
     {% if not (contract_name | regex_search('^[a-z]+(?:_[a-z]+)*$')) %}
     contract_name must be formatted in snake case.
     {% endif %}
+  when: "{{ use_deprecated_template }}"
 
 preset_name:
   type: str
@@ -47,6 +89,7 @@ preset_name:
     "Production - for confidently deploying to MainNet and/or more complex projects": "production"
     "Custom - for tailoring the template output to your needs": "custom"
   default: "starter"
+  when: "{{ use_deprecated_template }}"
 
 deployment_language:
   type: str
@@ -55,41 +98,43 @@ deployment_language:
     Python: "python"
     TypeScript: "typescript"
   default: "python"
+  when: "{{ use_deprecated_template }}"
 
 ide_vscode:
   type: bool
   help: Do you want to add VSCode configuration?
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   default: yes
 
 code_tours:
   type: bool
   help: Do you want to add interactive VSCode CodeTour walkthrough?
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   default: yes
 
 ide_jetbrains:
   type: bool
   help: Do you want to add JetBrains configuration (primarily optimized for PyCharm CE)?
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"
+  when: "{{ use_deprecated_template }}"
 
 use_python_pytest:
   type: bool
-  when: "{{ deployment_language == 'python' and preset_name == 'custom' }}"
+  when: "{{ deployment_language == 'python' and preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to include unit tests (via pytest)?
   default: "{{ 'yes' if preset_name == 'production' and deployment_language == 'python' else 'no' }}"
 
 use_typescript_jest:
   type: bool
-  when: "{{ deployment_language == 'typescript' and preset_name == 'custom' }}"
+  when: "{{ deployment_language == 'typescript' and preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to include unit tests (via jest)?
   default: "{{ 'yes' if preset_name == 'production' and deployment_language == 'typescript' else 'no' }}"
 
 python_linter:
   type: str
   help: Do you want to use a Python linter?
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   choices:
     Ruff: "ruff"
     Flake8: "flake8"
@@ -99,35 +144,35 @@ python_linter:
 use_python_black:
   type: bool
   help: Do you want to use a Python formatter (via Black)?
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"
 
 use_python_mypy:
   type: bool
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to use a Python type checker (via mypy)?
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"
 
 use_python_pip_audit:
   type: bool
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to include Python dependency vulnerability scanning (via pip-audit)?
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"
 
 use_github_actions:
   type: bool
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to include Github Actions workflows for build and testnet deployment?
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"
 
 use_pre_commit:
   type: bool
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to include pre-commit for linting, type checking and formatting?
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"
 
 use_dispenser:
   type: bool
-  when: "{{ preset_name == 'custom' }}"
+  when: "{{ preset_name == 'custom' and use_deprecated_template }}"
   help: Do you want to fund your deployment account using an optional dispenser account?
   default: "{{ 'yes' if preset_name == 'production' else 'no' }}"

--- a/template_content/post_init.py
+++ b/template_content/post_init.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+from tkinter import E
+
+
+def main():
+    # Get the use_deprecated_template argument
+    use_deprecated_template = sys.argv[1].lower() in ("true", "yes", "1", "t", "y")
+    use_workspace = sys.argv[2].lower() in ("true", "yes", "1", "t", "y")
+
+    if not use_deprecated_template:
+        # Get the parent directory of this script which should be the generated project root
+        project_dir = Path(__file__).parent
+        project_dir = project_dir.parent.parent if use_workspace else project_dir
+
+        # Print warning
+        print("WARNING: Template generation cancelled!\n")
+        print(
+            "This template is deprecated. Use Algorand Python instead: https://github.com/algorandfoundation/algokit-python-template\n"
+        )
+
+        os.chdir(project_dir.parent)
+        if project_dir.exists():
+            try:
+                shutil.rmtree(project_dir)
+            except Exception as e:
+                print(f"Error deleting project directory: {e}")
+                pass
+
+        sys.exit(1)
+
+    # If we get here, template was approved to be used
+    print("Proceeding with deprecated template generation...")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -176,6 +176,7 @@ def run_generator(
 
 
 @pytest.mark.parametrize("language", ["python", "typescript"])
+@pytest.mark.skip(reason="This test is deprecated since the template is deprecated")
 def test_smart_contract_generator_default_starter_preset(
     language: str, working_dir: Path
 ) -> None:
@@ -207,6 +208,7 @@ def test_smart_contract_generator_default_starter_preset(
 
 
 @pytest.mark.parametrize("language", ["python", "typescript"])
+@pytest.mark.skip(reason="This test is deprecated since the template is deprecated")
 def test_smart_contract_generator_default_production_preset(
     language: str, working_dir: Path
 ) -> None:
@@ -235,3 +237,17 @@ def test_smart_contract_generator_default_production_preset(
 
     response = check_codebase(working_dir, test_name)
     assert response.returncode == 0, response.stdout
+
+
+def test_template_fail() -> None:
+    test_name = "production_beaker_smart_contract_fail"
+
+    response = run_init(
+        root,
+        test_name,
+        answers={
+            "preset_name": "starter",
+            "deployment_language": "python",
+        },
+    )
+    assert response.returncode == 1, response.stdout

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -186,6 +186,7 @@ def get_questions_from_copier_yaml(
 
 
 @pytest.mark.parametrize(("question_name", "answer"), get_questions_from_copier_yaml())
+@pytest.mark.skip(reason="This test is deprecated since the template is deprecated")
 def test_parameters(working_dir: Path, question_name: str, answer: str | bool) -> None:
     response = run_init_kwargs(working_dir, **{question_name: answer})
     assert response.returncode == 0, response.stdout


### PR DESCRIPTION
## Proposed Changes

Slightly different approach to deprecation warning on beaker template:

- Reuses approach with custom tasks from fullstack template 
- - A dedicated post_init.py script which takes care of deleting cloned template content (copier has limitation in regards to only running tasks after template is instantiated)
- - Covers edge cases when init is done in workspaces vs no workspace mode
- - Covers edge cases when init is run from algokit binary where we need to use pre bundled python instead given that a user may not have python installed 